### PR TITLE
trim some spliterator/ jdk8 functions from v8 map

### DIFF
--- a/src/main/java/com/addthis/basis/collect/ConcurrentHashMapV8.java
+++ b/src/main/java/com/addthis/basis/collect/ConcurrentHashMapV8.java
@@ -33,7 +33,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
-import java.util.Spliterator;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;


### PR DESCRIPTION
not really going to be used in java7, and people using java8 can
just use the v8 map provided in java8. meanwhile, they cause
compile errors when using java8 even if the class isn't used.
